### PR TITLE
Upgrade lmdb module to 1.0

### DIFF
--- a/sample/requirements.txt
+++ b/sample/requirements.txt
@@ -1,3 +1,3 @@
 kaitaistruct==0.8
-lmdb==0.98
+lmdb==1.0
 nanolib==0.3


### PR DESCRIPTION
The `read.py` sample didn't work on latest Python3 version due to cffi errors. Upgrading the lmdb module solved the problem.